### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ policies, with an additional restriction to never remove deprecated interfaces.
 Resources
 ---------
 
-  * [Documentation](https://symfony.com/doc/current/components/contracts.html)
+  * [Documentation](https://symfony.com/components/Contracts)
   * [Contributing](https://symfony.com/doc/current/contributing/index.html)
   * [Report issues](https://github.com/symfony/symfony/issues) and
     [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
Fixed the link to the symfony cntracts component documentation. 
The old one doesn't work.