### PR TITLE
Support psr/container 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "psr/cache": "^1.0|^2.0|^3.0",
-        "psr/container": "^1.1",
+        "psr/container": "^1.1|^2.0",
         "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
We're hoping the 2.4/2.5 release can support psr/container 2 since it should be BC with 1.1.

https://github.com/php-fig/container/releases/tag/2.0.0

The only change is an added return type. Other projects are switching to psr/container and depending tend to his this package.